### PR TITLE
Trusted certificates forwarding to client node on bootstrap

### DIFF
--- a/raspbian-wheezy-gems.erb
+++ b/raspbian-wheezy-gems.erb
@@ -108,6 +108,11 @@ cat <<'EOP'
 EOP
 ) > /etc/chef/client.rb
 
+<% if @chef_config[:trusted_certs_dir] -%>
+mkdir -p /etc/chef/trusted_certs
+<%= trusted_certs_content %>
+<% end -%>
+
 (
 cat <<'EOP'
 <%= first_boot.to_json %>


### PR DESCRIPTION
Trusted certificates are copied over to the node being bootstrapped as with default knife behavior.
This is needed to check the Chef Server certificate when self-signed.
