### PR TITLE
Add Raspbian Jessie support using Stretch ruby2.3 - But Don't drop Wheezy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,28 @@
 
 ### install chef-client on raspberry pi (raspbian).  
 
-Chef doesn't offer a omnibus chef-client for raspberry pi yet.  This bootstrap script helps get around that by building ruby2.2 and gem installing chef-client onto the node.  
+Chef doesn't offer a omnibus chef-client for raspberry pi yet.  This bootstrap script helps get around that by building ruby and gem installing chef-client onto the node.
+
+There are bootstrap scripts to support both raspbian-wheezy and raspbian-jessie. Replace the release codename with the OS running on your Raspberry Pi.  For example: Replace `<lsb_codename_here>` in `raspbian-<lsb_codename_here>-gems.erb` with the output of `lsb_release -c -s` on your Pi.
 
 Before you start check the following:
 * your chef workstation environment is setup and ready with knife
 * your pi is on the network and you can login as root
 * have some patience - this will take a while
 
-This script has been tested against raspbian-wheezy but should likely work gracefully for other linux systems.
+This script has been tested against raspbian-wheezy, and raspbian-jessie but should likely work gracefully for other Debian-based Linux systems.
 
 ## installation ##
 
-    knife bootstrap -t raspbian-wheezy-gems.erb -x root address_of_your_pi
+    knife bootstrap -t raspbian-$(ssh root@<address_of_your_pi> 'lsb_release -c -s')-gems.erb -x root address_of_your_pi
 
 Or to sudo in via pi user if you don't have root access (I set up my ssh keys first)
 
-    knife bootstrap -t raspbian-wheezy-gems.erb --ssh-user pi --sudo address_of_your_pi
+    knife bootstrap -t raspbian-$(ssh root@<address_of_your_pi> 'lsb_release -c -s')-gems.erb --ssh-user pi --sudo address_of_your_pi
 
 A full on example of one that applies  What I personally will be doing later for new Pi's is applying my [d-base](https://github.com/dayne/d-base) cookbook as part of default run list.
 
-    knife bootstrap -t raspbian-wheezy-gems.erb --ssh-user pi --ssh-password '{{password}}' --sudo --node-name NODE_NAME_YOU_WANT --run-list 'recipe[d-base::default]'
+    knife bootstrap -t raspbian-$(ssh root@<address_of_your_pi> 'lsb_release -c -s')-gems.erb --ssh-user pi --ssh-password '{{password}}' --sudo --node-name NODE_NAME_YOU_WANT --run-list 'recipe[d-base::default]'
 
 ## Ramifications of using this script ##
 
@@ -32,10 +34,12 @@ A full on example of one that applies  What I personally will be doing later for
 
 ## Pre-compiled /opt/chef
 
-Note: I have a short attention span and waiting for ruby to compile on a pi is boring. You have option of using my prebuilt /opt/chef if you want. Just open up the script and twiddle the `false` to `true`. Just look for the comment around line 19.
+Note: I have a short attention span and waiting for ruby to compile on a pi is boring. You have option of using my prebuilt /opt/chef if you want. Just open up the script and twiddle the `false` to `true`. Just look for the comment around line 19. Currently an image only exists for `ruby2.2` built for Raspbian `wheezy`.
 
 # Credits and Contributors
 
 * @tinoschroeter : [Tino Schröter](https://github.com/tinoschroeter/raspbian_bootstrap) as original author
 * @dayne : [dayne](http://dayne.broderson.org) updated and evolved to support Chef 12
 * @in-bto : [ino-bto](https://github.com/ino-bto) for [trusted certs forwarding to client node](https://github.com/dayne/raspbian_bootstrap/pull/1)
+* @Edubits: [Edubits](https://github.com/Edubits) updated to Jessie
+* @trinitronx: [trinitronx](https://github.com/trinitronx) Merged support for both Wheezy and Jessie

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 ### raspbian_bootstrap ###
 
-### install chef-client on raspberry pi (raspbian).  
+### install `chef-client` on raspberry pi (`raspbian`).
 
-Chef doesn't offer a omnibus chef-client for raspberry pi yet.  This bootstrap script helps get around that by building ruby and gem installing chef-client onto the node.
+Chef doesn't offer a omnibus `chef-client` for raspberry pi yet.  This `knife bootstrap` script helps get around that by building `ruby` and gem installing `chef-client` onto the node.  There are bootstrap scripts to support both `raspbian-wheezy` and `raspbian-jessie`. The commands below replace the release codename with the OS running on your Raspberry Pi. If for some reason you do not wish to run `ssh` in the subshell, just replace it manually.
 
-There are bootstrap scripts to support both raspbian-wheezy and raspbian-jessie. Replace the release codename with the OS running on your Raspberry Pi.  For example: Replace `<lsb_codename_here>` in `raspbian-<lsb_codename_here>-gems.erb` with the output of `lsb_release -c -s` on your Pi.
+For example: Replace `<lsb_codename_here>` in `raspbian-<lsb_codename_here>-gems.erb` with the output of `lsb_release -c -s` on your Pi.
 
 Before you start check the following:
-* your chef workstation environment is setup and ready with knife
+
+* your chef workstation environment is setup and ready with `knife`
 * your pi is on the network and you can login as root
 * have some patience - this will take a while
 
-This script has been tested against raspbian-wheezy, and raspbian-jessie but should likely work gracefully for other Debian-based Linux systems.
+This script has been tested against `raspbian-wheezy`, and `raspbian-jessie` but should likely work gracefully for other Debian-*based* Linux systems.
 
 ## installation ##
 
@@ -21,20 +22,20 @@ Or to sudo in via pi user if you don't have root access (I set up my ssh keys fi
 
     knife bootstrap -t raspbian-$(ssh root@<address_of_your_pi> 'lsb_release -c -s')-gems.erb --ssh-user pi --sudo address_of_your_pi
 
-A full on example of one that applies  What I personally will be doing later for new Pi's is applying my [d-base](https://github.com/dayne/d-base) cookbook as part of default run list.
+A full on example of a `knife` command that applies a Chef recipe. What I personally will be doing later for new Pi's is applying my [d-base](https://github.com/dayne/d-base) cookbook as part of default `run_list`.
 
     knife bootstrap -t raspbian-$(ssh root@<address_of_your_pi> 'lsb_release -c -s')-gems.erb --ssh-user pi --ssh-password '{{password}}' --sudo --node-name NODE_NAME_YOU_WANT --run-list 'recipe[d-base::default]'
 
 ## Ramifications of using this script ##
 
-* [ruby-build](https://github.com/rbenv/ruby-build) installed in `/usr/local/bin`
-* `/opt/chef` with a ruby 2.2 compiled from ruby-build.
-* pi's clock will be synchronized and pi running [ntpd](http://doc.ntp.org/4.1.0/ntpd.htm) (network time protocol daemon).
-* `/usr/local/bin/chef-client` to run chef-client with right path for chef & ruby.
+* [`ruby-build`](https://github.com/rbenv/ruby-build) installed in `/usr/local/bin`
+* `/opt/chef` with a ruby (`wheezy: 2.2`, `jessie: 2.3`) compiled from `ruby-build`.
+* pi's clock will be synchronized and pi running [`ntpd`](http://doc.ntp.org/4.1.0/ntpd.htm) (network time protocol daemon).
+* `/usr/local/bin/chef-client` to run `chef-client` with right path for Chef & `ruby`.
 
 ## Pre-compiled /opt/chef
 
-Note: I have a short attention span and waiting for ruby to compile on a pi is boring. You have option of using my prebuilt /opt/chef if you want. Just open up the script and twiddle the `false` to `true`. Just look for the comment around line 19. Currently an image only exists for `ruby2.2` built for Raspbian `wheezy`.
+Note: I have a short attention span and waiting for ruby to compile on a pi is boring. You have option of using my prebuilt `/opt/chef` if you want. Just open up the script and twiddle the `false` to `true`. Just look for the comment around **line 19**. Currently an image only exists for `ruby2.2` built for Raspbian `wheezy`.
 
 # Credits and Contributors
 

--- a/raspbian-jessie-gems.erb
+++ b/raspbian-jessie-gems.erb
@@ -1,0 +1,80 @@
+sh -c '
+<%= "export https_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+
+# Add Stretch repository to apt for Ruby 2.3 packages
+echo "deb http://archive.raspbian.org/raspbian/ stretch main" > /etc/apt/sources.list.d/stretch.list
+
+# Update the Apt index
+apt-get update
+
+# Remove any existing Ruby versions
+apt-get purge ruby -y
+
+# Install new packages
+DEBIAN_FRONTEND=noninteractive apt-get install -y curl ruby2.3 ruby2.3-dev autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev
+
+# As we are using Stretch for the Ruby 2.3 packages not all dependencies can be correctly installed, force them
+apt-get -f install
+
+gem install moneta --no-rdoc --no-ri --verbose
+gem install net-ssh-gateway --no-rdoc --no-ri --verbose
+gem install net-ssh --no-rdoc --no-ri --verbose
+gem install ohai --no-rdoc --no-ri --verbose
+gem install chef --no-rdoc --no-ri --verbose
+
+# Add Chef configurations
+mkdir -p /etc/chef
+
+<% if client_pem -%>
+    cat > /etc/chef/client.pem <<EOP
+<%= ::File.read(::File.expand_path(client_pem)) %>
+EOP
+chmod 0600 /etc/chef/client.pem
+<% end -%>
+
+<% if validation_key -%>
+    cat > /etc/chef/validation.pem <<EOP
+<%= validation_key %>
+EOP
+chmod 0600 /etc/chef/validation.pem
+<% end -%>
+
+<% if encrypted_data_bag_secret -%>
+    cat > /etc/chef/encrypted_data_bag_secret <<EOP
+<%= encrypted_data_bag_secret %>
+EOP
+chmod 0600 /etc/chef/encrypted_data_bag_secret
+<% end -%>
+
+<% unless trusted_certs.empty? -%>
+    mkdir -p /etc/chef/trusted_certs
+    <%= trusted_certs %>
+<% end -%>
+
+<%# Generate Ohai Hints -%>
+<% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
+    mkdir -p /etc/chef/ohai/hints
+
+    <% @chef_config[:knife][:hints].each do |name, hash| -%>
+        cat > /etc/chef/ohai/hints/<%= name %>.json <<EOP
+<%= Chef::JSONCompat.to_json(hash) %>
+EOP
+    <% end -%>
+<% end -%>
+
+cat > /etc/chef/client.rb <<EOP
+<%= config_content %>
+EOP
+
+cat > /etc/chef/first-boot.json <<EOP
+<%= Chef::JSONCompat.to_json(first_boot) %>
+EOP
+
+<% unless client_d.empty? -%>
+mkdir -p /etc/chef/client.d
+<%= client_d %>
+<% end -%>
+
+echo "Starting the first Chef Client run..."
+
+<%= start_chef %>'


### PR DESCRIPTION
Hello, I figured since these are simple `.erb` scripts, there is no need to trash the `wheezy` support.  This is essentially the same as #2, but just keeps the old script in place.  It seems they are both slightly different in a bunch of places, otherwise I'd try to merge them both into one `.erb` and try to do some fancy platform detection via a `case` statement... but that can get messy fast.  Separate files seem to work well enough & easier to manage when things start to diverge more.
